### PR TITLE
closes #8: rejoin split blocks when empty

### DIFF
--- a/kernel/memory/allocator.rs
+++ b/kernel/memory/allocator.rs
@@ -52,14 +52,18 @@ impl BitvTrait for Bitv {
     fn get(&self, i: uint) -> Node {
         let w = i / 16;
         let b = (i % 16) * 2;
-        unsafe { transmute(((*self.storage)[w] as uint >> b) as u8 & 3) }
+        unsafe { 
+            transmute(((*self.storage)[w] as uint >> b) as u8 & 3)
+        }
     }
 
     #[inline]
     fn set(&self, i: uint, x: Node) {
         let w = i / 16;
         let b = (i % 16) * 2;
-        unsafe { (*self.storage)[w] = (((*self.storage)[w] & !(3 << b)) | (x as u32 << b)); }
+        unsafe { 
+            (*self.storage)[w] = (((*self.storage)[w] & !(3 << b)) | (x as u32 << b));
+        }
     }
 
     #[inline]
@@ -98,12 +102,16 @@ impl BuddyAlloc {
         /* } */
     }
 
+    fn lg2_size(self, size: uint) -> uint {
+        32 - unsafe { ctlz32(size as i32 - 1) } as uint
+    }
+
     fn alloc(&mut self, mut size: uint) -> (uint, uint) {
         if size == 0 {
             size = 1;
         }
         // smallest power of 2 >= size
-        let lg2_size = 32 - unsafe { ctlz32(size as i32 - 1) } as uint;
+        let lg2_size = self.lg2_size(size);
 
         let mut index = 0; // points to current tree node
         let mut level = self.order; // current height
@@ -156,7 +164,7 @@ impl BuddyAlloc {
 
                     if index == 0 {
                         // out of memory -- back at tree's root after traversal
-			out_of_memory();
+                    out_of_memory();
                         return (0, 0);
                     }
 
@@ -170,11 +178,32 @@ impl BuddyAlloc {
         let mut length = 1 << self.order;
         let mut left = 0;
         let mut index = 0;
-
+        let mut order = self.order; // current height
         loop {
             match self.tree.get(index) {
-                UNUSED => return,
-                USED => self.tree.set(index, UNUSED),
+                UNUSED => { 
+                    return
+                },
+                USED => { 
+                    // Free *this* block.
+                    self.tree.set(index, UNUSED);
+
+                    // Check for buddy block to free.
+                    let mut parent = index;
+                    loop {
+                        let buddy = parent - 1 + (parent & 1) * 2;
+                        match self.tree.get(buddy) {
+                            UNUSED if parent > 0 => {
+                                // Go up one, free the parent, check the
+                                // parent's buddy. Repeat until we don't have
+                                // an empty split block above us.
+                                parent = (parent + 1) / 2 - 1;
+                                self.tree.set(parent, UNUSED);
+                            }
+                            _ => break
+                        }
+                    }
+                },
                 _ => {
                     length /= 2;
                     if offset < left + length {


### PR DESCRIPTION
The old allocator wasn't looking at the block next to a freed block when
deallocating memory. Instead it was just freeing the block it was on.
This inspects the buddy of a given block when it is freed, and if the
buddy is also empty then it goes up and changes the parent from SPLIT to
UNUSED.

This solves the problem of constantly using more memory even though
memory was still being freed, something you could pick up on earlier if
you added debug statements to allocator.rs that print the locations
of allocs when they happen.
