### PR TITLE
Port to Rust 0.10

### DIFF
--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -4,7 +4,7 @@ TARGET := arm-linux-noeabi
 GCC_PREFIX := $(GCC_PREFIX)arm-none-eabi-
 
 RUSTC := $(RUST_ROOT)/bin/rustc
-RUSTCFLAGS := -O --target $(TARGET) -Z no-landing-pads -Z debug-info -Z extra-debug-info
+RUSTCFLAGS := --debuginfo 1 -O --target $(TARGET) -Z no-landing-pads
 
 AS := $(GCC_PREFIX)as
 LD := $(GCC_PREFIX)ld
@@ -18,7 +18,8 @@ QEMU := qemu-system-arm
 QEMUFLAGS := -M versatilepb -m 32M -serial stdio
 
 BDIR := ./boot
-CORE_LIB := ../../rust-core/core/lib.rs
+CORE_DIR := ../../rust-core
+CORE_LIB := $(CORE_DIR)/core/lib.rs
 LCORE := $(BDIR)/$(shell $(RUSTC) --crate-file-name $(CORE_LIB))
 OBJS := $(BDIR)/loader.o $(BDIR)/aeabi_runtime.o $(BDIR)/main.o $(BDIR)/core.o
 LINK := $(BDIR)/linker.ld $(OBJS)
@@ -36,14 +37,15 @@ all: $(BDIR)/kernel.bin
 
 # Library rust-core
 $(LCORE):
-	$(RUSTC) $(RUSTCFLAGS) --dep-info $(@D)/core.d $(CORE_LIB) --out-dir $(BDIR)
+	$(RUSTC) $(RUSTCFLAGS) --cfg libc $(CORE_DIR)/core/lib.rs --out-dir $(BDIR)
+	$(RUSTC) $(RUSTCFLAGS) --dep-info $(@D)/core.d $(CORE_LIB) --crate-type=lib --emit=bc  -C passes=inline --out-dir $(BDIR)
 
 $(BDIR)/core.bc: $(LCORE)
 	cd $(@D); ar -x $(<F) $(@F)
 
 # Compile rustboot
-$(BDIR)/main.bc: ../../lib.rs $(MODS) $(LCORE)
-	$(RUSTC) $(RUSTCFLAGS) --dep-info $(@D)/main.d -L $(BDIR) --emit-llvm ../../lib.rs --out-dir $(BDIR)
+$(BDIR)/main.bc:  $(LCORE) ../../lib.rs $(MODS)
+	$(RUSTC) $(RUSTCFLAGS) --emit=bc --dep-info $(@D)/main.d -L $(CORE_DIR) -L $(BDIR) ../../lib.rs --out-dir $(BDIR)
 
 %.s: %.bc
 	$(LLC) $(LLCFLAGS) $^ -o $@

--- a/arch/arm/drivers/mod.rs
+++ b/arch/arm/drivers/mod.rs
@@ -15,10 +15,10 @@ pub fn init() {
 }
 
 // A pointer to a rust function for dealing with UART0 Data
-pub static mut uart0_rec: Option<extern unsafe fn(char)> = None;
+pub static mut uart0_rec: Option<unsafe fn(char)> = None;
 
 // A pointer to a rust function for dealing with KMI0 Data (PS/2 Keyboard)
-pub static mut kmi0_rec:  Option<extern unsafe fn(u8)> = None;
+pub static mut kmi0_rec:  Option<unsafe fn(u8)> = None;
 
 // this fires on all Interrupts; so we need to check which interrupt triggered it,
 #[no_mangle]

--- a/kernel/commands.rs
+++ b/kernel/commands.rs
@@ -1,32 +1,119 @@
-use super::cstr;
-use super::sgash;
+use core::option::{Some, Option, None};
+use kernel::cstr::cstr;
 
-static mut curr_dir: cstr::cstr = cstr::cstr {
+pub static mut filesystem: Option<fs> = None;
+
+pub struct fs {
+    head: ~inode,
+    current: Option<*inode>,
+}
+
+impl fs {
+    pub unsafe fn new() -> fs { 
+        let mut nfs = fs {
+            head: ~inode::new(),
+            current: None,
+        };
+        nfs.current = nfs.head.child;
+        nfs
+    }
+
+    pub unsafe fn link_dir(sibling: *inode) -> Option<*inode> {
+        
+    }
+}
+
+pub struct inode {
+    name: Option<cstr>,
+    parent: Option<*inode>,
+    child: Option<*inode>,
+    left: Option<*inode>,
+    right: Option<*inode>,
+    data: Option<cstr>,
+}
+
+impl inode {
+    pub unsafe fn new() -> inode {
+        inode {
+            parent: None,
+            child: None,
+            left: None,
+            right: None,
+            name: None,
+            data: None,
+        }
+    }
+
+    unsafe fn new_dhead() -> inode {
+        inode {
+            parent: None,
+            child: None,
+            left: None,
+            right: None,
+            name: None,
+            data: None,
+        }
+    }
+
+    unsafe fn new_dir(name: cstr, link: *inode) -> inode {
+        inode {
+            parent: None,
+            child: Some(~inode::new_dhead()),
+            left: Some(link),
+            right: None,
+            name: None,
+            data: None,
+        }
+    }
+
+    pub fn is_dir(&self) {
+        self.child.is_some()
+    }
+
+    pub fn is_dhead(&self) {
+        self.left.is_none()
+    }
+    
+    pub fn is_file(&self) {
+        // Nothing will be files for 1st prototype
+        self.data.is_some()
+    }
+
+    pub fn unlink() {
+        // Does nothing yet
+    }
+}
+
+static mut curr_dir: cstr = cstr {
     p: 0 as *mut u8,
     p_cstr_i: 0,
     size: 0,
 };
 
-pub fn ls(dirname: cstr::cstr) {
+pub fn ls(dirname: cstr) {
 }
 
-pub fn cat(filename: cstr::cstr) {
+pub fn cat(filename: cstr) {
 }
 
-pub fn cd(newdir: cstr::cstr) {
+pub fn cd(newdir: cstr) {
 }
 
-pub fn rm(filename: cstr::cstr) {
+pub fn rm(filename: cstr) {
 }
 
-pub fn mkdir(dirname: cstr::cstr) {
+pub fn mkdir(dirname: cstr) {
 }
 
 pub fn pwd() {
 }
 
-pub fn mv(from: cstr::cstr, to: cstr::cstr) {
+pub fn mv(from: cstr, to: cstr) {
 }
 
-pub fn wr(filename: cstr::cstr, string: cstr::cstr) {
+pub fn wr(filename: cstr, string: cstr) {
+}
+
+pub unsafe fn init() {
+    filesystem = fs::new();
 }

--- a/kernel/commands.rs
+++ b/kernel/commands.rs
@@ -1,8 +1,8 @@
 use core::option::{Some, Option, None};
-use kernel::cstr::cstr;
+use kernel::cstr::Cstr;
 
+/*
 pub static mut filesystem: Option<fs> = None;
-
 pub struct fs {
     head: ~inode,
     current: Option<*inode>,
@@ -14,7 +14,6 @@ impl fs {
             head: ~inode::new(),
             current: None,
         };
-        nfs.current = nfs.head.child;
         nfs
     }
 
@@ -24,12 +23,12 @@ impl fs {
 }
 
 pub struct inode {
-    name: Option<cstr>,
-    parent: Option<*inode>,
-    child: Option<*inode>,
-    left: Option<*inode>,
-    right: Option<*inode>,
-    data: Option<cstr>,
+    name: Option<*mut Cstr>,
+    parent: Option<*mut inode>,
+    child: Option<*mut inode>,
+    left: Option<*mut inode>,
+    right: Option<*mut inode>,
+    data: Option<*mut Cstr>,
 }
 
 impl inode {
@@ -55,10 +54,10 @@ impl inode {
         }
     }
 
-    unsafe fn new_dir(name: cstr, link: *inode) -> inode {
+    unsafe fn new_dir(name: Cstr, link: *inode) -> inode {
         inode {
             parent: None,
-            child: Some(~inode::new_dhead()),
+            child: Some(inode::new_dhead() as *u32),
             left: Some(link),
             right: None,
             name: None,
@@ -66,15 +65,15 @@ impl inode {
         }
     }
 
-    pub fn is_dir(&self) {
+    pub fn is_dir(&self) -> bool {
         self.child.is_some()
     }
 
-    pub fn is_dhead(&self) {
+    pub fn is_dhead(&self) -> bool {
         self.left.is_none()
     }
     
-    pub fn is_file(&self) {
+    pub fn is_file(&self) -> bool {
         // Nothing will be files for 1st prototype
         self.data.is_some()
     }
@@ -84,36 +83,32 @@ impl inode {
     }
 }
 
-static mut curr_dir: cstr = cstr {
+static mut curr_dir: Cstr = Cstr {
     p: 0 as *mut u8,
     p_cstr_i: 0,
     size: 0,
 };
-
-pub fn ls(dirname: cstr) {
+*/
+pub fn ls(dirname: Cstr) {
 }
 
-pub fn cat(filename: cstr) {
+pub fn cat(filename: Cstr) {
 }
 
-pub fn cd(newdir: cstr) {
+pub fn cd(newdir: Cstr) {
 }
 
-pub fn rm(filename: cstr) {
+pub fn rm(filename: Cstr) {
 }
 
-pub fn mkdir(dirname: cstr) {
+pub fn mkdir(dirname: Cstr) {
 }
 
 pub fn pwd() {
 }
 
-pub fn mv(from: cstr, to: cstr) {
+pub fn mv(from: Cstr, to: Cstr) {
 }
 
-pub fn wr(filename: cstr, string: cstr) {
-}
-
-pub unsafe fn init() {
-    filesystem = fs::new();
+pub fn wr(filename: Cstr, string: Cstr) {
 }

--- a/kernel/commands.rs
+++ b/kernel/commands.rs
@@ -1,5 +1,6 @@
 use core::option::{Some, Option, None};
 use kernel::cstr::Cstr;
+use kernel::sgash::drawstr;
 
 /*
 pub static mut filesystem: Option<fs> = None;
@@ -65,20 +66,20 @@ impl inode {
         }
     }
 
-    pub fn is_dir(&self) -> bool {
+    pub unsafe fn is_dir(&self) -> bool {
         self.child.is_some()
     }
 
-    pub fn is_dhead(&self) -> bool {
+    pub unsafe fn is_dhead(&self) -> bool {
         self.left.is_none()
     }
     
-    pub fn is_file(&self) -> bool {
+    pub unsafe fn is_file(&self) -> bool {
         // Nothing will be files for 1st prototype
         self.data.is_some()
     }
 
-    pub fn unlink() {
+    pub unsafe fn unlink() {
         // Does nothing yet
     }
 }
@@ -89,26 +90,31 @@ static mut curr_dir: Cstr = Cstr {
     size: 0,
 };
 */
-pub fn ls(dirname: Cstr) {
+pub unsafe fn ls(dirname: Cstr) {
+    drawstr(&". rusty\n");
 }
 
-pub fn cat(filename: Cstr) {
+pub unsafe fn cat(filename: Cstr) {
+    if filename.streq(&"rusty") {
+        drawstr(&"kernel\n");
+    }
 }
 
-pub fn cd(newdir: Cstr) {
+pub unsafe fn cd(newdir: Cstr) {
 }
 
-pub fn rm(filename: Cstr) {
+pub unsafe fn rm(filename: Cstr) {
 }
 
-pub fn mkdir(dirname: Cstr) {
+pub unsafe fn mkdir(dirname: Cstr) {
 }
 
-pub fn pwd() {
+pub unsafe fn pwd() {
+    drawstr(&"/\n");
 }
 
-pub fn mv(from: Cstr, to: Cstr) {
+pub unsafe fn mv(from: Cstr, to: Cstr) {
 }
 
-pub fn wr(filename: Cstr, string: Cstr) {
+pub unsafe fn wr(filename: Cstr, string: Cstr) {
 }

--- a/kernel/cstr.rs
+++ b/kernel/cstr.rs
@@ -5,8 +5,6 @@ use core::str::*;
 use core::option::{Some, Option, None}; // Match statement
 use core::iter::Iterator;
 use kernel::*;
-use core::mem::transmute;
-use core::container;
 use super::super::platform::*;
 use kernel::memory::Allocator;
 

--- a/kernel/cstr.rs
+++ b/kernel/cstr.rs
@@ -1,5 +1,5 @@
 /* kernel::cstr.rs */
-#[allow(unused_imports)];
+#![allow(unused_imports)]
 use core::*;
 use core::str::*;
 use core::option::{Some, Option, None}; // Match statement
@@ -11,25 +11,25 @@ use kernel::memory::Allocator;
 pub static DEFAULT_STRLEN: uint = 256;
 pub static mut first: bool = true;
 
-pub struct cstr {
+pub struct Cstr {
     p: *mut u8,
     p_cstr_i: uint,
     size: uint
 }
 
-impl cstr {
-    pub fn new() -> cstr {
+impl Cstr {
+    pub fn new() -> Cstr {
         unsafe {
-            cstr::news(DEFAULT_STRLEN)
+            Cstr::news(DEFAULT_STRLEN)
         }
     }
 
-    pub unsafe fn news(size: uint) -> cstr {
+    pub unsafe fn news(size: uint) -> Cstr {
         // Sometimes this doesn't allocate enough memory and gets stuck...
         if first { let (_, _) = heap.alloc(size); }
         first = false;
         let (x, y) = heap.alloc(size);
-        let this = cstr {
+        let this = Cstr {
             p: x,
             p_cstr_i: 0,
             size: y
@@ -38,8 +38,8 @@ impl cstr {
         this
     }
 
-    pub fn from_str(s: &str) -> cstr {
-        let mut this = cstr::new();
+    pub fn from_str(s: &str) -> Cstr {
+        let mut this = Cstr::new();
         for c in slice::iter(as_bytes(s)) {
             this.add_u8(*c);
         };
@@ -60,19 +60,19 @@ impl cstr {
         }
     }
 
-    pub unsafe fn join(&self, other: cstr) -> cstr {
+    pub unsafe fn join(&self, other: Cstr) -> Cstr {
         let mut len = DEFAULT_STRLEN;
         while len < self.len() + other.len() {
             len += DEFAULT_STRLEN;
         }
-        let mut new = cstr::news(len);
+        let mut new = Cstr::news(len);
         self.map(|c| { new.add_char(c); } );
         other.map(|c| { new.add_char(c); } );
         new
     }
 
-    pub unsafe fn trim(&mut self) -> cstr {
-        let mut new = cstr::new();
+    pub unsafe fn trim(&mut self) -> Cstr {
+        let mut new = Cstr::new();
         if self.len() == 0 || self.size > new.size {
             return new;
         }
@@ -105,9 +105,9 @@ impl cstr {
         return new;
     }
 
-    pub unsafe fn clone(&mut self) -> cstr {
+    pub unsafe fn clone(&mut self) -> Cstr {
         let mut ind: uint = 0;
-        let mut s = cstr::news(self.size);
+        let mut s = Cstr::news(self.size);
         loop {
             if (self.len() == 0 || ind == self.len()) {
                 return s;
@@ -174,7 +174,7 @@ impl cstr {
         *(self.p as *mut char) = '\0';
     }
 
-    pub unsafe fn eq(&self, other: &cstr) -> bool {
+    pub unsafe fn eq(&self, other: &Cstr) -> bool {
         if (self.len() != other.len()) { return false; }
         else {
             let mut x = 0;
@@ -202,14 +202,14 @@ impl cstr {
     }
 
     #[allow(dead_code)]
-    pub unsafe fn split(&self, delim: char) -> (cstr, cstr) {
+    pub unsafe fn split(&self, delim: char) -> (Cstr, Cstr) {
         let mut i = 0;
-        let mut beg = cstr::news(self.size);
-        let mut end = cstr::news(self.size);
+        let mut beg = Cstr::news(self.size);
+        let mut end = Cstr::news(self.size);
         self.map(|c| {beg.add_char(c);});
         let mut found = false;
         while i < self.len() && !found {
-            if (!found && beg.get_char(i) as u8 == delim as u8) {
+            if !found && beg.get_char(i) as u8 == delim as u8 {
                 found = true;
                 match beg.get_p(i) {
                     Some(p) => *(p as *mut char) = '\0',

--- a/kernel/cstr.rs
+++ b/kernel/cstr.rs
@@ -5,6 +5,8 @@ use core::str::*;
 use core::option::{Some, Option, None}; // Match statement
 use core::iter::Iterator;
 use kernel::*;
+use core::mem::transmute;
+use core::container;
 use super::super::platform::*;
 use kernel::memory::Allocator;
 
@@ -54,10 +56,12 @@ impl Cstr {
     
     pub fn map(&self, f: |char|) {
         let mut i = 0;
+        /*
         while i < self.len() && self.get_char(i) != '\0' {
             f(self.get_char(i));
             i += 1;
         }
+        */
     }
 
     pub unsafe fn join(&self, other: Cstr) -> Cstr {
@@ -188,17 +192,6 @@ impl Cstr {
             }
             true
         }
-    }
-
-    pub unsafe fn streq(&self, other: &str) -> bool {
-        let mut i = 0;
-        for c in slice::iter(as_bytes(other)) {
-            if i > self.len() || *c != (self.get_char(i) as u8) {
-                return false;
-            }
-            i += 1;
-        };
-        i == self.len()
     }
 
     #[allow(dead_code)]

--- a/kernel/cstr.rs
+++ b/kernel/cstr.rs
@@ -56,12 +56,10 @@ impl Cstr {
     
     pub fn map(&self, f: |char|) {
         let mut i = 0;
-        /*
         while i < self.len() && self.get_char(i) != '\0' {
             f(self.get_char(i));
             i += 1;
         }
-        */
     }
 
     pub unsafe fn join(&self, other: Cstr) -> Cstr {

--- a/kernel/memory/allocator.rs
+++ b/kernel/memory/allocator.rs
@@ -63,7 +63,7 @@ impl BitvTrait for Bitv {
         let w = i / 16;
         let b = (i % 16) * 2;
         unsafe { 
-            (*self.storage)[w] = (((*self.storage)[w] & !(3 << b)) | (x as u32 << b));
+            (*self.storage)[w] = ((*self.storage)[w] & !(3 << b)) | (x as u32 << b);
         }
     }
 

--- a/kernel/memory/allocator.rs
+++ b/kernel/memory/allocator.rs
@@ -2,8 +2,6 @@ use core::mem::transmute;
 use core::ptr::{set_memory, copy_memory, offset};
 use core::i32::ctlz32;
 use core::fail::out_of_memory;
-
-use kernel::sgash;
 use kernel::ptr::mut_offset;
 
 #[repr(u8)]
@@ -232,8 +230,8 @@ impl Allocator for Alloc {
     fn alloc(&mut self, size: uint) -> (*mut u8, uint) {
         let (offset, size) = self.parent.alloc(size);
         unsafe {
-            let roffset = mut_offset(self.base, (offset << self.el_size) as int);
-            let rsize = size << self.el_size;
+            let roffset: *mut u8 = mut_offset(self.base, (offset << self.el_size) as int);
+            let rsize: uint = size << self.el_size;
             return (roffset, rsize)
         }
     }

--- a/kernel/mod.rs
+++ b/kernel/mod.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)];
+#![allow(unused_imports)]
 
 use core::option::{Option, Some, None};
 use core::fail::out_of_memory;
@@ -13,7 +13,7 @@ pub mod memory;
 pub mod sgash;
 pub mod cstr;
 pub mod kbd;
-//pub mod commands;
+pub mod commands;
 
 #[cfg(target_word_size = "32")]
 pub mod rt;

--- a/kernel/mod.rs
+++ b/kernel/mod.rs
@@ -13,7 +13,7 @@ pub mod memory;
 pub mod sgash;
 pub mod cstr;
 pub mod kbd;
-pub mod commands;
+//pub mod commands;
 
 #[cfg(target_word_size = "32")]
 pub mod rt;

--- a/kernel/rt.rs
+++ b/kernel/rt.rs
@@ -6,7 +6,7 @@
  * udivmoddi4
  */
 
-#[allow(ctypes)];
+#![allow(ctypes)]
 
 use core::i32::{ctlz32, cttz32};
 use core::mem::{transmute, size_of};

--- a/kernel/sgash.rs
+++ b/kernel/sgash.rs
@@ -132,7 +132,6 @@ pub unsafe fn parse_buffer() {
     buffer.map(|c| drawchar(c));
     showstr(&"\n");
     let (command, args) = buffer.split(' ');
-    /* TODO: this Worked in Rust 0.9
     if command.streq(&"echo") {
         args.map(|c| drawchar(c));
         args.map(putchar);
@@ -167,7 +166,6 @@ pub unsafe fn parse_buffer() {
     else {
         showstr(UNRECOGNIZED);
     }
-    */
     command.destroy();
     args.destroy();
 }

--- a/kernel/sgash.rs
+++ b/kernel/sgash.rs
@@ -132,6 +132,7 @@ pub unsafe fn parse_buffer() {
     buffer.map(|c| drawchar(c));
     showstr(&"\n");
     let (command, args) = buffer.split(' ');
+    /* TODO: this Worked in Rust 0.9
     if command.streq(&"echo") {
         args.map(|c| drawchar(c));
         args.map(putchar);
@@ -166,6 +167,7 @@ pub unsafe fn parse_buffer() {
     else {
         showstr(UNRECOGNIZED);
     }
+    */
     command.destroy();
     args.destroy();
 }

--- a/kernel/sgash.rs
+++ b/kernel/sgash.rs
@@ -1,12 +1,12 @@
 /* kernel::sgash.rs */
-#[allow(unused_imports)];
+#![allow(unused_imports)]
 use core::*;
 use core::str::*;
 use core::option::{Some, Option, None};
 use core::mem::volatile_store;
 use core::iter::Iterator;
 use kernel::*;
-use kernel::cstr::cstr;
+use kernel::cstr::Cstr;
 use super::super::platform::*;
 use super::super::platform::cpu::uart;
 use kernel::memory::Allocator;
@@ -18,7 +18,7 @@ static UNRECOGNIZED: &'static str = &"Err: Unrecognized command\n";
 static PROMPT_COLOR: u32 = 0xFFAF00;
 static mut count: uint = 0;
 
-static mut buffer: cstr = cstr {
+static mut buffer: Cstr = Cstr {
     p: 0 as *mut u8,
     p_cstr_i: 0,
     size: 0,
@@ -30,7 +30,7 @@ pub fn putnum(x: uint, max: uint) {
     if i == 0 {
         i = 1000000;
     }
-    while(i > 0) {
+    while i > 0 {
         // Get the offset from each decimal point up to a certain value
         putchar(((((x / i) % 10) as u8) + ('0' as u8)) as char);
         i /= 10;
@@ -71,7 +71,7 @@ unsafe fn drawchar(x: char) {
         io::CURSOR_Y += io::CURSOR_HEIGHT;
         io::CURSOR_X = 0u32;
     } else {
-        if (((x as u8) as uint) >= 32 && ((x as u8) as uint) <= 125) {
+        if ((x as u8) as uint) >= 32 && ((x as u8) as uint) <= 125 {
             io::draw_char(x);
             io::CURSOR_X += io::CURSOR_WIDTH;
         }
@@ -83,7 +83,7 @@ unsafe fn drawchar(x: char) {
 
 unsafe fn backspace() {
     io::restore();
-    if (io::CURSOR_X >= io::CURSOR_WIDTH) {
+    if io::CURSOR_X >= io::CURSOR_WIDTH {
         io::CURSOR_X -= io::CURSOR_WIDTH;
         io::draw_char(' ');
     }
@@ -129,11 +129,11 @@ pub unsafe fn from_keyboard(x: u8) {
 pub unsafe fn parse_buffer() {
     showstr(&"\n");
     buffer.map(putchar);
-    buffer.map(drawchar);
+    buffer.map(|c| drawchar(c));
     showstr(&"\n");
     let (command, args) = buffer.split(' ');
     if command.streq(&"echo") {
-        args.map(drawchar);
+        args.map(|c| drawchar(c));
         args.map(putchar);
         showstr(&"\n");
     }
@@ -215,7 +215,7 @@ pub unsafe fn screen() {
 }
 
 pub unsafe fn init() {
-    buffer = cstr::new();
+    buffer = Cstr::new();
     screen();
     prompt();
 }

--- a/kernel/sgash.rs
+++ b/kernel/sgash.rs
@@ -11,7 +11,7 @@ use super::super::platform::*;
 use super::super::platform::cpu::uart;
 use kernel::memory::Allocator;
 
-use commands;
+//use commands;
 
 static PROMPT: &'static str = &"sgash> ";
 static UNRECOGNIZED: &'static str = &"Err: Unrecognized command\n";

--- a/lib.rs
+++ b/lib.rs
@@ -1,16 +1,15 @@
 /* main.rs */
 
-#[crate_id = "main#0.1"];
-#[comment = "ironkernel"];
-#[license = "MIT"];
-#[crate_type = "lib"];
+#![crate_id = "main#0.1"]
+#![comment = "ironkernel"]
+#![license = "MIT"]
+#![crate_type = "lib"]
 // Forked from pczarn/rustboot
-#[no_std];
-#[feature(asm, globs, macro_rules)];
+#![no_std]
+#![feature(asm, globs, macro_rules)]
 
-#[allow(attribute_usage)];
-#[allow(dead_code)];
-extern mod core;
+#![allow(attribute_usage)]
+extern crate core;
 
 #[cfg(target_arch = "arm")]
 pub use support::{memcpy, memmove};


### PR DESCRIPTION
This doesn't have a working cstring implementation, but I would argue that any Rust code written for 0.9 is going to become worthless exponentially fast now that 0.10 is out. Any future efforts should focus on improving a 0.10 version, not dragging 0.9 through the dirt.

In case anyone decides to work off this codebase later, we would do well to have a bootable 0.10 version in `master`.
